### PR TITLE
Handle setItem exceptions

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -65,9 +65,10 @@ That's it. Now your redux state will be stored in localstorage.
        returns string which can be stored into storage.
      - **deserialize**: *function* (default: **JSON.parse**) a function which takes string from storage and returns
        object with redux state.
-     - **map**: *object* (default: **{}**) a [mapping transformation](https://github.com/adam-golab/redux-phoenix#transformation) wich will be applied to state before saving.
+     - **map**: *object* (default: **{}**) a [mapping transformation](https://github.com/adam-golab/redux-phoenix#transformation) which will be applied to state before saving.
      - **disabled**: *boolean* (default: **false**) disable persisting state.
-     - **throttle**: *number* (default: **0**) number of milisecond to wait between persisting the state, for values greater than 0 it uses [throttled](https://github.com/adam-golab/redux-phoenix#throttle) version.
+     - **throttle**: *number* (default: **0**) number of milliseconds to wait between persisting the state, for values greater than 0 it uses [throttled](https://github.com/adam-golab/redux-phoenix#throttle) version.
+     - **handleException**: *function* (default: **null**) a function which takes an error object thrown by a `storage.setItem()` exception and dictates how to handle it.
 
 #### `autoRehydrate`
 

--- a/README.MD
+++ b/README.MD
@@ -68,7 +68,7 @@ That's it. Now your redux state will be stored in localstorage.
      - **map**: *object* (default: **{}**) a [mapping transformation](https://github.com/adam-golab/redux-phoenix#transformation) which will be applied to state before saving.
      - **disabled**: *boolean* (default: **false**) disable persisting state.
      - **throttle**: *number* (default: **0**) number of milliseconds to wait between persisting the state, for values greater than 0 it uses [throttled](https://github.com/adam-golab/redux-phoenix#throttle) version.
-     - **handleException**: *function* (default: **null**) a function which takes an error object thrown by a `storage.setItem()` exception and dictates how to handle it.
+     - **handleException**: *function* (default: **null**) a function which takes 1) an error object thrown by a `storage.setItem()` exception, and 2) the `storage` reference, and dictates how to handle the error.
 
 #### `autoRehydrate`
 

--- a/src/reduxPhoenix.js
+++ b/src/reduxPhoenix.js
@@ -141,7 +141,7 @@ export default function persistStore(store, {
       // overwrite storage value; catch exceptions and handle
       const exceptionHandler = handleException && typeof handleException === 'function'
         ? handleException
-        : (e, storage) => console.log(e.message || 'storage error: setItem()');
+        : (e, storage) => {}; // noop
 
       try {
         storage.setItem(key, serialize({

--- a/src/reduxPhoenix.js
+++ b/src/reduxPhoenix.js
@@ -141,7 +141,7 @@ export default function persistStore(store, {
       // overwrite storage value; catch exceptions and handle
       const exceptionHandler = handleException && typeof handleException === 'function'
         ? handleException
-        : e => console.log(e.message || 'storage error: setItem()');
+        : (e, storage) => console.log(e.message || 'storage error: setItem()');
 
       try {
         storage.setItem(key, serialize({
@@ -150,7 +150,7 @@ export default function persistStore(store, {
           migrations: appliedMigrations,
         }));
       } catch (e) {
-        exceptionHandler(e);
+        exceptionHandler(e, storage);
       }
     };
 


### PR DESCRIPTION
Catch exceptions from `setItem` call (e.g. limit exceeded) and provide a hook for handling them.
Defaults to a console log.